### PR TITLE
instrument: add instrumentation with prometheus

### DIFF
--- a/internal/incoming/incoming_conn.go
+++ b/internal/incoming/incoming_conn.go
@@ -33,6 +33,7 @@ import (
 	"github.com/katzenpost/core/wire"
 	"github.com/katzenpost/core/wire/commands"
 	"github.com/katzenpost/server/internal/debug"
+	"github.com/katzenpost/server/internal/instrument"
 	"github.com/katzenpost/server/internal/packet"
 	"gopkg.in/op/go-logging.v1"
 )
@@ -207,6 +208,7 @@ func (c *incomingConn) worker() {
 			continue
 		}
 
+		instrument.Incoming(rawCmd)
 		if c.fromClient {
 			switch cmd := rawCmd.(type) {
 			case *commands.RetrieveMessage:

--- a/internal/instrument/dummy.go
+++ b/internal/instrument/dummy.go
@@ -1,0 +1,13 @@
+// +build !prometheus
+
+package instrument
+
+import (
+	"github.com/katzenpost/core/wire/commands"
+)
+
+// Init instrumentation
+func Init() {}
+
+// Incomming increments the counter for incomming requests
+func Incoming(cmd commands.Command) {}

--- a/internal/instrument/prometheus.go
+++ b/internal/instrument/prometheus.go
@@ -1,0 +1,36 @@
+// +build prometheus
+
+package instrument
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/katzenpost/core/wire/commands"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	incoming = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "katzenpost_incoming_total",
+			Help: "Number of incoming requests.",
+		},
+		[]string{"command"},
+	)
+)
+
+// Init instrumentation
+func Init() {
+	prometheus.MustRegister(incoming)
+
+	http.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(":6543", nil)
+}
+
+// Incoming increments the counter for incomming requests
+func Incoming(cmd commands.Command) {
+	typeStr := fmt.Sprintf("%T", cmd)
+	incoming.With(prometheus.Labels{"command": typeStr})
+}

--- a/server.go
+++ b/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/katzenpost/server/internal/cryptoworker"
 	"github.com/katzenpost/server/internal/glue"
 	"github.com/katzenpost/server/internal/incoming"
+	"github.com/katzenpost/server/internal/instrument"
 	"github.com/katzenpost/server/internal/outgoing"
 	"github.com/katzenpost/server/internal/pki"
 	"github.com/katzenpost/server/internal/provider"
@@ -192,6 +193,8 @@ func (s *Server) halt() {
 // New returns a new Server instance parameterized with the specified
 // configuration.
 func New(cfg *config.Config) (*Server, error) {
+	instrument.Init()
+
 	s := &Server{
 		cfg:        cfg,
 		fatalErrCh: make(chan error),


### PR DESCRIPTION
It can be enabled using a compilation tag 'prometheus'. If no tag is
provided a dummy implementation with empty functions will be compiled so
all the instrumentation calls don't do anything.

Part of #40