### PR TITLE
Add Identity() implementation for external UserDB

### DIFF
--- a/internal/provider/kaetzchen/keyserver.go
+++ b/internal/provider/kaetzchen/keyserver.go
@@ -98,6 +98,7 @@ func (k *kaetzchenKeyserver) OnRequest(id uint64, payload []byte, hasSURB bool) 
 		// identity key to make enumeration attacks minutely harder.
 		resp.StatusCode = keyserverStatusNoIdentity
 	default:
+		resp.StatusCode = keyserverStatusSyntaxError
 	}
 	if err != nil {
 		k.log.Debugf("Failed to service request: %v (%v)", id, err)

--- a/userdb/externuserdb/externuserdb.go
+++ b/userdb/externuserdb/externuserdb.go
@@ -99,7 +99,6 @@ func (e *externAuth) Identity(u []byte) (*ecdh.PublicKey, error) {
 				}
 			}
 		}
-		return nil, err
 	}
 	return nil, userdb.ErrNoIdentity
 }

--- a/userdb/externuserdb/externuserdb.go
+++ b/userdb/externuserdb/externuserdb.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"encoding/hex"
 	"github.com/katzenpost/core/crypto/ecdh"
 	"github.com/katzenpost/server/userdb"
 	"github.com/ugorji/go/codec"
@@ -74,7 +75,33 @@ func (e *externAuth) SetIdentity(u []byte, k *ecdh.PublicKey) error {
 }
 
 func (e *externAuth) Identity(u []byte) (*ecdh.PublicKey, error) {
-	return nil, errNotSupported
+	endpoint := "getidkey"
+	uri := e.provider + "/" + endpoint
+	form := url.Values{"user": {string(u)}}
+	rsp, err := http.PostForm(uri, form)
+	if err != nil {
+		return nil, err
+	}
+	defer rsp.Body.Close()
+
+	response := map[string]string{}
+	d := codec.NewDecoder(rsp.Body, jsonHandle)
+	if err = d.Decode(&response); err != nil {
+		return nil, err
+	}
+
+	if rsp.StatusCode == 200 {
+		if pkhex, ok := response[endpoint]; ok {
+			if decoded, err := hex.DecodeString(pkhex); err == nil {
+				pk := new(ecdh.PublicKey)
+				if err := pk.FromBytes(decoded); err == nil {
+					return pk, nil
+				}
+			}
+		}
+		return nil, err
+	}
+	return nil, userdb.ErrNoIdentity
 }
 
 func (e *externAuth) Remove(u []byte) error {


### PR DESCRIPTION
enables querying the user identity key through the external userdb api