### PR TITLE
Fix mix key erasure bug

### DIFF
--- a/mixkey.go
+++ b/mixkey.go
@@ -109,7 +109,7 @@ func (m *mixKeys) Prune() bool {
 	defer m.Unlock()
 
 	for idx, v := range m.keys {
-		if idx < epoch {
+		if idx < epoch-1 {
 			m.log.Debugf("Purging expired key for epoch: %v", idx)
 			v.Deref()
 			delete(m.keys, idx)


### PR DESCRIPTION
wtf are there so many layer of abstraction all complected and interacting with each other. srsly wtf. this two character fix... can you fathom how many hours this fix took me to find? why does this fix work?

it's complicated but briefly:
Fact A:
server/internal/mixkey's Deref method called forceClose method when ref count reaches zero. forceClose doesn't remove the file from disk unless k.epoch < epoch -1.

Fact B:
server/mixkey's Prune method calls Deref when idx < epoch and returns true.

Fact C:
server/internal/pki/pki.go's publishDescriptorIfNeeded method calls Prune and if that returns true it calls ReshadowCryptoWorkers which causes a Deref to be called.

Since Prune decides too early that a given mixKey has expired it causes all the references to be remove without the file being deleted from disk since it's notion of expire disagrees with that of forceClose in Fact A.

