### PR TITLE
Fixed typo in 'Vacuum'

### DIFF
--- a/internal/provider/kaetzchen/kaetzchen_test.go
+++ b/internal/provider/kaetzchen/kaetzchen_test.go
@@ -80,7 +80,7 @@ func (s *mockSpool) Get(u []byte, advance bool) (msg, surbID []byte, remaining i
 
 func (s *mockSpool) Remove(u []byte) error { return nil }
 
-func (s *mockSpool) Vaccum(udb userdb.UserDB) error { return nil }
+func (s *mockSpool) Vacuum(udb userdb.UserDB) error { return nil }
 
 func (s *mockSpool) Close() {}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -779,7 +779,7 @@ func New(glue glue.Glue) (glue.Provider, error) {
 	}
 
 	// Purge spools that belong to users that no longer exist in the user db.
-	if err = p.spool.Vaccum(p.userDB); err != nil {
+	if err = p.spool.Vacuum(p.userDB); err != nil {
 		return nil, err
 	}
 

--- a/internal/sqldb/pgx.go
+++ b/internal/sqldb/pgx.go
@@ -338,14 +338,14 @@ func (s *pgxSpool) Remove(u []byte) error {
 	return s.pgx.doUserDelete(u)
 }
 
-func (s *pgxSpool) Vaccum(udb userdb.UserDB) error {
+func (s *pgxSpool) Vacuum(udb userdb.UserDB) error {
 	// This never needs to happen iff the database is acting as both the
 	// UserDB and spool.
 	if !s.pgx.IsSpoolOnly() {
 		return nil
 	}
 
-	s.pgx.d.log.Errorf("Vaccum() not supported yet.") // TODO
+	s.pgx.d.log.Errorf("Vacuum() not supported yet.") // TODO
 	return nil
 }
 

--- a/spool/boltspool/boltspool.go
+++ b/spool/boltspool/boltspool.go
@@ -197,7 +197,7 @@ func (s *boltSpool) Remove(u []byte) error {
 	})
 }
 
-func (s *boltSpool) Vaccum(udb userdb.UserDB) error {
+func (s *boltSpool) Vacuum(udb userdb.UserDB) error {
 	return s.db.Update(func(tx *bolt.Tx) error {
 		// Grab the `users` bucket.
 		uBkt := tx.Bucket([]byte(usersBucket))

--- a/spool/spool.go
+++ b/spool/spool.go
@@ -38,9 +38,9 @@ type Spool interface {
 	// Remove removes the spool identified by the username from the database.
 	Remove(u []byte) error
 
-	// Vaccum removes the spools that do not correspond to valid users in the
+	// Vacuum removes the spools that do not correspond to valid users in the
 	// provided UserDB.
-	Vaccum(udb userdb.UserDB) error
+	Vacuum(udb userdb.UserDB) error
 
 	// Close closes the Spool instance.
 	Close()


### PR DESCRIPTION
Vaccum => Vacuum

This being part of a public interface, I'm not sure where else it may be used,
so please review this pull request thoroughly.