### PR TITLE
Combined duplicate init() functions in internal/pki/pki.go

### DIFF
--- a/internal/pki/pki.go
+++ b/internal/pki/pki.go
@@ -46,10 +46,10 @@ import (
 )
 
 var (
-	errNotCached    = errors.New("pki: requested epoch document not in cache")
-	recheckInterval = 1 * time.Minute
-	WarpedEpoch     = "false"
-	nextFetchTill = epochtime.Period / 2
+	errNotCached         = errors.New("pki: requested epoch document not in cache")
+	recheckInterval      = 1 * time.Minute
+	WarpedEpoch          = "false"
+	nextFetchTill        = epochtime.Period / 2
 	pkiEarlyConnectSlack = epochtime.Period / 6
 )
 
@@ -116,12 +116,6 @@ var (
 	)
 	fetchedPKIDocsTimer *prometheus.Timer
 )
-
-func init() {
-	prometheus.MustRegister(fetchedPKIDocs)
-	prometheus.MustRegister(fetchedPKIDocsDuration)
-	prometheus.MustRegister(failedFetchPKIDocs)
-}
 
 func (p *pki) StartWorker() {
 	p.Go(p.worker)
@@ -762,6 +756,10 @@ func makeDescAddrMap(addrs []string) (map[cpki.Transport][]string, error) {
 }
 
 func init() {
+	prometheus.MustRegister(fetchedPKIDocs)
+	prometheus.MustRegister(fetchedPKIDocsDuration)
+	prometheus.MustRegister(failedFetchPKIDocs)
+
 	if WarpedEpoch == "true" {
 		recheckInterval = 20 * time.Second
 	}


### PR DESCRIPTION
When working on instrumentation, I added an `init()` function to initialize some metrics. I didn't double check to see that there was already an `init()` for setting the `warpedEpoch` variable. I combined both into a single `init()` function.