### PR TITLE
Add updatable pki parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ LABEL authors="Christian Muehlhaeuser: muesli@gmail.com"
 # Can pass --build-arg warped=true to decrease epoch period
 ARG warped=false
 
+ENV ldflags="-X github.com/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/server/internal/pki.WarpedEpoch=${warped}"
+
 # Install git & make
 # Git is required for fetching the dependencies
 RUN apk update && \
@@ -16,11 +18,11 @@ WORKDIR /go/server
 
 # Build the binary
 COPY . .
-RUN cd cmd/server && go build -ldflags "-X github.com/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/server/internal/pki.WarpedEpoch=${warped}"
-RUN cd /go ; git clone https://github.com/katzenpost/memspool ; cd memspool/server/cmd/memspool ;  go build
-RUN cd /go ; git clone https://github.com/katzenpost/reunion ; cd reunion ; cd servers/reunion_katzenpost_server ; go build
-RUN cd /go ; git clone https://github.com/katzenpost/panda ; cd panda/server/cmd/panda_server ; go build
-RUN cd /go ; git clone https://github.com/katzenpost/server_plugins ; cd server_plugins/cbor_plugins/echo-go ; go build -o echo_server
+RUN cd cmd/server && go build -ldflags "$ldflags"
+RUN cd /go ; git clone https://github.com/katzenpost/memspool ; cd memspool/server/cmd/memspool ;  go build -ldflags "$ldflags"
+RUN cd /go ; git clone https://github.com/katzenpost/reunion ; cd reunion ; cd servers/reunion_katzenpost_server ; go build -ldflags "$ldflags"
+RUN cd /go ; git clone https://github.com/katzenpost/panda ; cd panda/server/cmd/panda_server ; go build -ldflags "$ldflags"
+RUN cd /go ; git clone https://github.com/katzenpost/server_plugins ; cd server_plugins/cbor_plugins/echo-go ; go build -o echo_server -ldflags "$ldflags"
 
 FROM alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL authors="Christian Muehlhaeuser: muesli@gmail.com"
 # Can pass --build-arg warped=true to decrease epoch period
 ARG warped=false
 
-ENV ldflags="-X github.com/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/server/internal/pki.WarpedEpoch=${warped}"
+ENV ldflags="-X github.com/katzenpost/core/epochtime.WarpedEpoch=${warped} -X github.com/katzenpost/server/internal/pki.WarpedEpoch=${warped} -X github.com/katzenpost/minclient/pki.WarpedEpoch=${warped}"
 
 # Install git & make
 # Git is required for fetching the dependencies

--- a/cborplugin/client.go
+++ b/cborplugin/client.go
@@ -101,8 +101,9 @@ type Client struct {
 
 // New creates a new plugin client instance which represents the single execution
 // of the external plugin program.
-func New(command string, logBackend *log.Backend) *Client {
+func New(command, capability string, logBackend *log.Backend) *Client {
 	return &Client{
+		capability: capability,
 		logBackend: logBackend,
 		log:        logBackend.GetLogger(command),
 		httpClient: nil,

--- a/cborplugin/client.go
+++ b/cborplugin/client.go
@@ -233,6 +233,11 @@ func (c *Client) GetParameters() *Parameters {
 		c.log.Debugf("decode failure: %s", err)
 		return nil
 	}
+	// XXX: why does this happen?
+	if responseParams == nil {
+		c.log.Debugf("no parameters set for %s", c.capability)
+		responseParams = make(Parameters)
+	}
 	responseParams["endpoint"] = c.endpoint
 	return &responseParams
 }

--- a/cborplugin/client.go
+++ b/cborplugin/client.go
@@ -70,6 +70,10 @@ type ServicePlugin interface {
 	// extracting the payload component of the message
 	OnRequest(request *Request) ([]byte, error)
 
+	// Capability returns the agent's functionality for publication in
+	// the Provider's descriptor.
+	Capability() string
+
 	// Parameters returns the agent's paramenters for publication in
 	// the Provider's descriptor.
 	GetParameters() *Parameters
@@ -91,6 +95,7 @@ type Client struct {
 	httpClient *http.Client
 	cmd        *exec.Cmd
 	socketPath string
+	capability string
 	params     *Parameters
 }
 
@@ -213,6 +218,13 @@ func (c *Client) OnRequest(request *Request) ([]byte, error) {
 		return nil, err
 	}
 	return response.Payload, nil
+}
+
+// Capability are used in Mix Descriptor publication to give
+// service clients more information about the service. Not
+// plugins will need to use this feature.
+func (c *Client) Capability() string {
+	return c.capability
 }
 
 // GetParameters are used in Mix Descriptor publication to give

--- a/internal/pki/pki.go
+++ b/internal/pki/pki.go
@@ -761,6 +761,6 @@ func init() {
 	prometheus.MustRegister(failedFetchPKIDocs)
 
 	if WarpedEpoch == "true" {
-		recheckInterval = 20 * time.Second
+		recheckInterval = 5 * time.Second
 	}
 }

--- a/internal/pki/pki.go
+++ b/internal/pki/pki.go
@@ -49,7 +49,7 @@ var (
 	errNotCached         = errors.New("pki: requested epoch document not in cache")
 	recheckInterval      = 1 * time.Minute
 	WarpedEpoch          = "false"
-	nextFetchTill        = epochtime.Period / 2
+	nextFetchTill        = epochtime.Period/8
 	pkiEarlyConnectSlack = epochtime.Period / 6
 )
 

--- a/internal/provider/kaetzchen/cbor_plugins.go
+++ b/internal/provider/kaetzchen/cbor_plugins.go
@@ -184,7 +184,6 @@ func (k *CBORPluginWorker) KaetzchenForPKI() ServiceMap {
 				params[key] = value
 			}
 		}
-		params[ParameterEndpoint] = capa
 		s[capa] = params
 	}
 	return s
@@ -196,9 +195,9 @@ func (k *CBORPluginWorker) IsKaetzchen(recipient [sConstants.RecipientIDLength]b
 	return ok
 }
 
-func (k *CBORPluginWorker) launch(command, capability string, args []string) (*cborplugin.Client, error) {
+func (k *CBORPluginWorker) launch(command, capability, endpoint string, args []string) (*cborplugin.Client, error) {
 	k.log.Debugf("Launching plugin: %s", command)
-	plugin := cborplugin.New(command, capability, k.glue.LogBackend())
+	plugin := cborplugin.New(command, capability, endpoint, k.glue.LogBackend())
 	err := plugin.Start(command, args)
 	return plugin, err
 }
@@ -261,7 +260,7 @@ func NewCBORPluginWorker(glue glue.Glue) (*CBORPluginWorker, error) {
 				}
 			}
 
-			pluginClient, err := kaetzchenWorker.launch(pluginConf.Command, pluginConf.Capability, args)
+			pluginClient, err := kaetzchenWorker.launch(pluginConf.Command, pluginConf.Capability, pluginConf.Endpoint, args)
 			if err != nil {
 				kaetzchenWorker.log.Error("Failed to start a plugin client: %s", err)
 				return nil, err

--- a/internal/provider/kaetzchen/cbor_plugins.go
+++ b/internal/provider/kaetzchen/cbor_plugins.go
@@ -249,10 +249,6 @@ func NewCBORPluginWorker(glue glue.Glue) (*CBORPluginWorker, error) {
 		copy(endpoint[:], rawEp)
 		kaetzchenWorker.pluginChans[endpoint] = channels.NewInfiniteChannel()
 
-		// Add entry from this plugin for the PKI.
-		params := make(map[string]interface{})
-		gotParams := false
-
 		// Start the plugin clients.
 		for i := 0; i < pluginConf.MaxConcurrency; i++ {
 			kaetzchenWorker.log.Noticef("Starting Kaetzchen plugin client: %s %d", capa, i)

--- a/internal/provider/kaetzchen/cbor_plugins.go
+++ b/internal/provider/kaetzchen/cbor_plugins.go
@@ -196,9 +196,9 @@ func (k *CBORPluginWorker) IsKaetzchen(recipient [sConstants.RecipientIDLength]b
 	return ok
 }
 
-func (k *CBORPluginWorker) launch(command string, args []string) (*cborplugin.Client, error) {
+func (k *CBORPluginWorker) launch(command, capability string, args []string) (*cborplugin.Client, error) {
 	k.log.Debugf("Launching plugin: %s", command)
-	plugin := cborplugin.New(command, k.glue.LogBackend())
+	plugin := cborplugin.New(command, capability, k.glue.LogBackend())
 	err := plugin.Start(command, args)
 	return plugin, err
 }
@@ -261,7 +261,7 @@ func NewCBORPluginWorker(glue glue.Glue) (*CBORPluginWorker, error) {
 				}
 			}
 
-			pluginClient, err := kaetzchenWorker.launch(pluginConf.Command, args)
+			pluginClient, err := kaetzchenWorker.launch(pluginConf.Command, pluginConf.Capability, args)
 			if err != nil {
 				kaetzchenWorker.log.Error("Failed to start a plugin client: %s", err)
 				return nil, err


### PR DESCRIPTION
This PR changes the provider so that it will query each plugin for its parameters each time it publishes a descriptor so that the parameters may be updated.